### PR TITLE
3-discord: Initial degradation

### DIFF
--- a/3-discord/README.md
+++ b/3-discord/README.md
@@ -1,0 +1,27 @@
+Failure:
+
+Redis Instance is migrated to new machine, which causes a rebalance of the redis cluster.
+
+The bad caching rules discovered by a known bug! Yikes! Bug might have been that it ignores some property of caching (like when it expires)
+After that goes through, it triggers a lot of traffic to actual API endpoints because of bad caching rules (and probably because cache was cold). This causes a failure in the cassandra cluster (not critical).
+
+How can a misconfigured edge caching rule cause the expensive route to be called when the cache reboots?
+
+Why the flip do they have to restart API instances to resolve latency issues? Perhaps they connect to a non-optimal region as a backup.
+
+Bad Behavior:
+
+Bad Behavior node creates cascading failure in other services:
+
+- Known Bug messes up caching rule
+- API level spikes from usage (and increased memory and latency)
+- Non-critical database crashes from overwhelming usage
+- Lots of memory leaks cause nodes to crash
+
+Interested in: when cache fails, what happens to systems that depends on cache above and below it.
+
+## Interesting Observed Behavior From Simulation
+
+### Failure Ripples
+
+After a node has failed, traffic drastically increases to the wrapped dependency for some time until the new replacement cache has warmed up. This happens again after the cache expires, at the rate at which the cache was filled. The rate of traffic slows the shock up, so it isnt as drastic. This ripple continues for several iterations.

--- a/3-discord/api-service.ts
+++ b/3-discord/api-service.ts
@@ -1,0 +1,34 @@
+import { Event, FIFOQueue, metronome, Stage, TimedDependency } from "../../src";
+
+type Status = "up" | "down";
+
+export class APIService extends TimedDependency {
+  public timeToRecover: number = 5000;
+  public maxConcurrency: number = 100;
+
+  private _state: Status = "up";
+  constructor() {
+    super();
+    this.inQueue = new FIFOQueue(1, 35);
+  }
+  async workOn(event: Event): Promise<void> {
+    if (this._state == "up") {
+      if (this.concurrent > this.maxConcurrency) {
+        const originalAvailability = this.availability;
+        metronome.setTimeout(() => {
+          this._state = "up"
+          this.availability = originalAvailability
+        }, this.timeToRecover);
+
+        this._state = "down";
+        this.availability = 0;
+      }
+    }
+
+    await super.workOn(event);
+  }
+
+  public get state(): Status {
+    return this._state;
+  }
+}

--- a/3-discord/incident.ts
+++ b/3-discord/incident.ts
@@ -1,0 +1,93 @@
+/**
+ * Models some of the architecture of Discord during the incident
+ * described in an October 2017 incident report.
+ * 
+ * https://discordstatus.com/incidents/qk9cdgnqnhcn
+ * 
+ */
+
+import {
+  simulation,
+  stageSummary,
+  eventSummary,
+  metronome,
+  stats,
+} from "../../src";
+import { APIService } from "./api-service";
+import { RedisCluster } from "./redis";
+
+
+const api = new APIService();
+const redis = new RedisCluster(api);
+
+// configuration
+api.mean = api.errorMean = 400;
+api.std = api.errorStd = 80;
+
+
+redis.ring.forEach(instance => {
+  instance.ttl = 50000;
+  instance.capacity = 500;
+});
+
+
+// scenario
+simulation.keyspaceMean = 1000;
+simulation.keyspaceStd = 200;
+simulation.eventsPer1000Ticks = 200;
+
+async function work() {
+  const events = await simulation.run(redis, 80000);
+  console.log("done");
+  stageSummary(redis.ring)
+  eventSummary(events);
+  stats.summary(true);
+}
+work();
+
+// stats
+function poll() {
+  const now = metronome.now();
+
+  const eventRate = simulation.getArrivalRate();
+  const obj: any = {
+    now, eventRate, apiLoad: api.concurrent, apiState: api.state
+  }
+  redis.ring.forEach((instance, index) => {
+    const key = `redis-${index}`
+    obj[key] = Object.keys(instance.getStore()).length
+  })
+
+  stats.record("poll", obj);
+}
+metronome.setInterval(poll, 1000);
+
+
+// fail a selection of nodes
+// observe ripple effect in cached data expiring at similar times
+// observe a large percent of requests with extended latency
+const firstFailTime = 50000;
+metronome.setTimeout(() => {
+  redis.failNode(0)
+  redis.failNode(1)
+  redis.failNode(2)
+  redis.failNode(3)
+  redis.failNode(4)
+}, firstFailTime)
+
+
+// cascading failure below (api layer)
+// re-fail the nodes, introduce a fatal configuration in the api service to 
+// allow the cache failure to cascade into the api layer
+// stop the failure after some time, so we can demonstrate other failures
+const secondFailTime = 200000;
+const allowFailTime = 100000;
+metronome.setTimeout(() => {
+  redis.failNode(0)
+  redis.failNode(1)
+  redis.failNode(2)
+  redis.failNode(3)
+  redis.failNode(4)
+}, secondFailTime)
+metronome.setTimeout(() => api.maxConcurrency = 30, secondFailTime);
+metronome.setTimeout(() => api.maxConcurrency = 50, secondFailTime + allowFailTime);

--- a/3-discord/redis.ts
+++ b/3-discord/redis.ts
@@ -1,0 +1,54 @@
+import { Event, LRUCache, Stage, WrappedStage } from "../../src";
+
+/**
+ * A model of the redis service.
+ * 
+ * 1 Master, 1 Replica
+ * 
+ * https://8kmiles.com/images/2014/09/ElastiCache-redis-as-a-Data-store-with-Ketama-Consistent-hashing.jpg
+ */
+
+export class RedisCluster extends WrappedStage {
+  public readonly ring: RedisInstance[] = [];
+  protected _killedNodes: RedisInstance[] = [];
+
+  constructor(protected wrapped: Stage) {
+    super(wrapped);
+
+    for (let i = 0; i < 10; i++) {
+      // i.e.
+      // even index = master
+      // odd index = replica
+      this.ring.push(new RedisInstance(wrapped));
+    }
+  }
+
+  // Choose a redis Intance to Serve the Request
+  async workOn(event: Event): Promise<void> {
+    const instance = this.sendTrafficTo(event);
+    await instance.accept(event);
+  }
+
+  private sendTrafficTo(event: Event): RedisInstance {
+    const index = parseInt(event.key.slice(2)) % 10;
+    return this.ring[index];
+  }
+
+  /**
+   * Fails an existing node by removing it from the ring
+   * Spins up a new instance in its place. 
+   * @param index 
+   */
+  public failNode(index: number) {
+    const old = this.ring[index];
+    const instance = new RedisInstance(this.wrapped);
+    this._killedNodes.push(old);
+    this.ring[index] = instance;
+
+    instance.ttl = old.ttl;
+    instance.capacity = old.capacity;
+  }
+}
+
+
+class RedisInstance extends LRUCache { }


### PR DESCRIPTION
This degradation only includes a degradation if the redis layer and the layer below it, despite the incident report talking about numerous other cascading failures (cassandraDB, nodes out of memory, etc a few days after)